### PR TITLE
negative thresholds disable alert creation for 3xx,4xx,5xx,target_res…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
+
+
+
+
 ## Usage
 
 ```hcl
@@ -59,13 +64,13 @@ module "alb_alarms" {
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
-| target_3xx_count_threshold | The maximum count of 3XX requests over a period. | string | `25` | no |
-| target_4xx_count_threshold | The maximum count of 4XX requests over a period. | string | `25` | no |
-| target_5xx_count_threshold | The maximum count of 5XX requests over a period. | string | `25` | no |
+| target_3xx_count_threshold | The maximum count of 3XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| target_4xx_count_threshold | The maximum count of 4XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| target_5xx_count_threshold | The maximum count of 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_group_arn_suffix | The ARN suffix of ALB Target Group. | string | - | yes |
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |
-| target_response_time_threshold | The maximum average target response time (in seconds) over a period. | string | `0.5` | no |
+| target_response_time_threshold | The maximum average target response time (in seconds) over a period. A negative value will disable the alert. | string | `0.5` | no |
 
 
 
@@ -164,6 +169,13 @@ See [LICENSE](LICENSE) for full details.
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
+
+
+
+
+
+
 
 
 ## Trademarks

--- a/alarms.tf
+++ b/alarms.tf
@@ -6,6 +6,11 @@ locals {
     TargetResponseTimeThreshold = "${max(var.target_response_time_threshold, 0)}"
   }
 
+  Target3XXAlarmEnabled          = "${var.target_3xx_count_threshold < 0     ? 0 : 1 * local.enabled}"
+  Target4XXAlarmEnabled          = "${var.target_4xx_count_threshold < 0     ? 0 : 1 * local.enabled}"
+  Target5XXAlarmEnabled          = "${var.target_5xx_count_threshold < 0     ? 0 : 1 * local.enabled}"
+  TargetResponseTimeAlarmEnabled = "${var.target_response_time_threshold < 0 ? 0 : 1 * local.enabled}"
+
   dimensions_map = {
     "TargetGroup"  = "${join("/", list("targetgroup", var.target_group_name, var.target_group_arn_suffix))}"
     "LoadBalancer" = "${join("/", list("app", var.alb_name, var.alb_arn_suffix))}"
@@ -21,7 +26,7 @@ module "httpcode_alarm_label" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_3xx_count" {
-  count               = "${local.enabled}"
+  count               = "${local.Target3XXAlarmEnabled}"
   alarm_name          = "${format(module.httpcode_alarm_label.id, "3XX")}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "${var.evaluation_periods}"
@@ -38,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_3xx_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_4xx_count" {
-  count               = "${local.enabled}"
+  count               = "${local.Target4XXAlarmEnabled}"
   alarm_name          = "${format(module.httpcode_alarm_label.id, "4XX")}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "${var.evaluation_periods}"
@@ -55,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_4xx_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
-  count               = "${local.enabled}"
+  count               = "${local.Target5XXAlarmEnabled}"
   alarm_name          = "${format(module.httpcode_alarm_label.id, "5XX")}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "${var.evaluation_periods}"
@@ -80,7 +85,7 @@ module "target_response_time_alarm_label" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
-  count               = "${local.enabled}"
+  count               = "${local.TargetResponseTimeAlarmEnabled}"
   alarm_name          = "${format(module.target_response_time_alarm_label.id)}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "${var.evaluation_periods}"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,11 +16,11 @@
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
-| target_3xx_count_threshold | The maximum count of 3XX requests over a period. | string | `25` | no |
-| target_4xx_count_threshold | The maximum count of 4XX requests over a period. | string | `25` | no |
-| target_5xx_count_threshold | The maximum count of 5XX requests over a period. | string | `25` | no |
+| target_3xx_count_threshold | The maximum count of 3XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| target_4xx_count_threshold | The maximum count of 4XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| target_5xx_count_threshold | The maximum count of 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_group_arn_suffix | The ARN suffix of ALB Target Group. | string | - | yes |
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |
-| target_response_time_threshold | The maximum average target response time (in seconds) over a period. | string | `0.5` | no |
+| target_response_time_threshold | The maximum average target response time (in seconds) over a period. A negative value will disable the alert. | string | `0.5` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,19 +76,19 @@ variable "period" {
 
 variable "target_3xx_count_threshold" {
   type        = "string"
-  description = "The maximum count of 3XX requests over a period."
+  description = "The maximum count of 3XX requests over a period. A negative value will disable the alert."
   default     = "25"
 }
 
 variable "target_4xx_count_threshold" {
   type        = "string"
-  description = "The maximum count of 4XX requests over a period."
+  description = "The maximum count of 4XX requests over a period. A negative value will disable the alert."
   default     = "25"
 }
 
 variable "target_5xx_count_threshold" {
   type        = "string"
-  description = "The maximum count of 5XX requests over a period."
+  description = "The maximum count of 5XX requests over a period. A negative value will disable the alert."
   default     = "25"
 }
 
@@ -100,7 +100,7 @@ variable "httpcode_alarm_description" {
 
 variable "target_response_time_threshold" {
   type        = "string"
-  description = "The maximum average target response time (in seconds) over a period."
+  description = "The maximum average target response time (in seconds) over a period. A negative value will disable the alert."
   default     = "0.5"
 }
 


### PR DESCRIPTION
## what
* Negative thresholds will disable alert creation

## why
* Sometimes not all response code alerts are desirable
