### PR TITLE
expose treat_missing_data, and add new {ok,alarm,insufficient_data}_actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ module "alb_alarms" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an ALARM state from any other state.  If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | alb_arn_suffix | The ARN suffix of ALB. | string | - | yes |
 | alb_name | The name of ALB to monitor. | string | - | yes |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
@@ -58,9 +59,11 @@ module "alb_alarms" {
 | enabled | Whether to create all resources. | string | `true` | no |
 | evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | httpcode_alarm_description | The string to format and use as the httpcode alarm description. | string | `HTTPCode %v count for %v over %v last %d minute(s) over %v period(s)` | no |
+| insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | name | Name (unique identifier for app or service) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| notify_arns | A list of ARNs (i.e. SNS Topic ARN) to notify on alarm and ok actions. | list | - | yes |
+| notify_arns | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into ANY state from any other state. May be overridden by the value of a more specific {alarm,ok,insufficient_data}_actions variable. | list | `<list>` | no |
+| ok_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an OK state from any other state. If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
@@ -71,6 +74,7 @@ module "alb_alarms" {
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |
 | target_response_time_threshold | The maximum average target response time (in seconds) over a period. A negative value will disable the alert. | string | `0.5` | no |
+| treat_missing_data | Sets how alarms handle missing data points. Values supported: missing, ignore, breaching and notBreaching. | string | `missing` | no |
 
 
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,4 +1,9 @@
 locals {
+  # default to using notify_arns unless a more specific action is specified.
+  alarm_actions             = "${coalescelist(var.alarm_actions,var.notify_arns)}"
+  ok_actions                = "${coalescelist(var.ok_actions,var.notify_arns)}"
+  insufficient_data_actions = "${coalescelist(var.insufficient_data_actions,var.notify_arns)}"
+
   thresholds = {
     target_3xx_count     = "${max(var.target_3xx_count_threshold, 0)}"
     target_4xx_count     = "${max(var.target_4xx_count_threshold, 0)}"
@@ -26,52 +31,58 @@ module "httpcode_alarm_label" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_3xx_count" {
-  count               = "${local.target_3xx_alarm_enabled}"
-  alarm_name          = "${format(module.httpcode_alarm_label.id, "3XX")}"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "${var.evaluation_periods}"
-  metric_name         = "HTTPCode_Target_3XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "${var.period}"
-  statistic           = "Sum"
-  threshold           = "${local.thresholds["target_3xx_count"]}"
-  alarm_description   = "${format(var.httpcode_alarm_description, "3XX", module.default_label.id, local.thresholds["target_3xx_count"], var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${var.notify_arns}"]
-  ok_actions          = ["${var.notify_arns}"]
+  count                     = "${local.target_3xx_alarm_enabled}"
+  alarm_name                = "${format(module.httpcode_alarm_label.id, "3XX")}"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "${var.evaluation_periods}"
+  metric_name               = "HTTPCode_Target_3XX_Count"
+  namespace                 = "AWS/ApplicationELB"
+  period                    = "${var.period}"
+  statistic                 = "Sum"
+  threshold                 = "${local.thresholds["target_3xx_count"]}"
+  treat_missing_data        = "${var.treat_missing_data}"
+  alarm_description         = "${format(var.httpcode_alarm_description, "3XX", module.default_label.id, local.thresholds["target_3xx_count"], var.period/60, var.evaluation_periods)}"
+  alarm_actions             = ["${local.alarm_actions}"]
+  ok_actions                = ["${local.ok_actions}"]
+  insufficient_data_actions = ["${local.insufficient_data_actions}"]
 
   dimensions = "${local.dimensions_map}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_4xx_count" {
-  count               = "${local.target_4xx_alarm_enabled}"
-  alarm_name          = "${format(module.httpcode_alarm_label.id, "4XX")}"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "${var.evaluation_periods}"
-  metric_name         = "HTTPCode_Target_4XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "${var.period}"
-  statistic           = "Sum"
-  threshold           = "${local.thresholds["target_4xx_count"]}"
-  alarm_description   = "${format(var.httpcode_alarm_description, "4XX", module.default_label.id, local.thresholds["target_4xx_count"], var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${var.notify_arns}"]
-  ok_actions          = ["${var.notify_arns}"]
+  count                     = "${local.target_4xx_alarm_enabled}"
+  alarm_name                = "${format(module.httpcode_alarm_label.id, "4XX")}"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "${var.evaluation_periods}"
+  metric_name               = "HTTPCode_Target_4XX_Count"
+  namespace                 = "AWS/ApplicationELB"
+  period                    = "${var.period}"
+  statistic                 = "Sum"
+  threshold                 = "${local.thresholds["target_4xx_count"]}"
+  treat_missing_data        = "${var.treat_missing_data}"
+  alarm_description         = "${format(var.httpcode_alarm_description, "4XX", module.default_label.id, local.thresholds["target_4xx_count"], var.period/60, var.evaluation_periods)}"
+  alarm_actions             = ["${local.alarm_actions}"]
+  ok_actions                = ["${local.ok_actions}"]
+  insufficient_data_actions = ["${local.insufficient_data_actions}"]
 
   dimensions = "${local.dimensions_map}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
-  count               = "${local.target_5xx_alarm_enabled}"
-  alarm_name          = "${format(module.httpcode_alarm_label.id, "5XX")}"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "${var.evaluation_periods}"
-  metric_name         = "HTTPCode_Target_5XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "${var.period}"
-  statistic           = "Sum"
-  threshold           = "${local.thresholds["target_5xx_count"]}"
-  alarm_description   = "${format(var.httpcode_alarm_description, "5XX", module.default_label.id, local.thresholds["target_5xx_count"], var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${var.notify_arns}"]
-  ok_actions          = ["${var.notify_arns}"]
+  count                     = "${local.target_5xx_alarm_enabled}"
+  alarm_name                = "${format(module.httpcode_alarm_label.id, "5XX")}"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "${var.evaluation_periods}"
+  metric_name               = "HTTPCode_Target_5XX_Count"
+  namespace                 = "AWS/ApplicationELB"
+  period                    = "${var.period}"
+  statistic                 = "Sum"
+  threshold                 = "${local.thresholds["target_5xx_count"]}"
+  treat_missing_data        = "${var.treat_missing_data}"
+  alarm_description         = "${format(var.httpcode_alarm_description, "5XX", module.default_label.id, local.thresholds["target_5xx_count"], var.period/60, var.evaluation_periods)}"
+  alarm_actions             = ["${local.alarm_actions}"]
+  ok_actions                = ["${local.ok_actions}"]
+  insufficient_data_actions = ["${local.insufficient_data_actions}"]
 
   dimensions = "${local.dimensions_map}"
 }
@@ -85,18 +96,20 @@ module "target_response_time_alarm_label" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
-  count               = "${local.target_response_time_alarm_enabled}"
-  alarm_name          = "${format(module.target_response_time_alarm_label.id)}"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "${var.evaluation_periods}"
-  metric_name         = "TargetResponseTime"
-  namespace           = "AWS/ApplicationELB"
-  period              = "${var.period}"
-  statistic           = "Average"
-  threshold           = "${local.thresholds["target_response_time"]}"
-  alarm_description   = "${format(var.target_response_time_alarm_description, module.default_label.id, local.thresholds["target_response_time"], var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${var.notify_arns}"]
-  ok_actions          = ["${var.notify_arns}"]
+  count                     = "${local.target_response_time_alarm_enabled}"
+  alarm_name                = "${format(module.target_response_time_alarm_label.id)}"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = "${var.evaluation_periods}"
+  metric_name               = "TargetResponseTime"
+  namespace                 = "AWS/ApplicationELB"
+  period                    = "${var.period}"
+  statistic                 = "Average"
+  threshold                 = "${local.thresholds["target_response_time"]}"
+  treat_missing_data        = "${var.treat_missing_data}"
+  alarm_description         = "${format(var.target_response_time_alarm_description, module.default_label.id, local.thresholds["target_response_time"], var.period/60, var.evaluation_periods)}"
+  alarm_actions             = ["${local.alarm_actions}"]
+  ok_actions                = ["${local.ok_actions}"]
+  insufficient_data_actions = ["${local.insufficient_data_actions}"]
 
   dimensions = "${local.dimensions_map}"
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,6 +3,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an ALARM state from any other state.  If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | alb_arn_suffix | The ARN suffix of ALB. | string | - | yes |
 | alb_name | The name of ALB to monitor. | string | - | yes |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
@@ -10,9 +11,11 @@
 | enabled | Whether to create all resources. | string | `true` | no |
 | evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | httpcode_alarm_description | The string to format and use as the httpcode alarm description. | string | `HTTPCode %v count for %v over %v last %d minute(s) over %v period(s)` | no |
+| insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | name | Name (unique identifier for app or service) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| notify_arns | A list of ARNs (i.e. SNS Topic ARN) to notify on alarm and ok actions. | list | - | yes |
+| notify_arns | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into ANY state from any other state. May be overridden by the value of a more specific {alarm,ok,insufficient_data}_actions variable. | list | `<list>` | no |
+| ok_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an OK state from any other state. If set, this list takes precedence over notify_arns. | list | `<list>` | no |
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
@@ -23,4 +26,5 @@
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |
 | target_response_time_threshold | The maximum average target response time (in seconds) over a period. A negative value will disable the alert. | string | `0.5` | no |
+| treat_missing_data | Sets how alarms handle missing data points. Values supported: missing, ignore, breaching and notBreaching. | string | `missing` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,26 @@ variable "enabled" {
 
 variable "notify_arns" {
   type        = "list"
-  description = "A list of ARNs (i.e. SNS Topic ARN) to notify on alarm and ok actions."
+  description = "A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into ANY state from any other state. May be overridden by the value of a more specific {alarm,ok,insufficient_data}_actions variable. "
+  default     = []
+}
+
+variable "alarm_actions" {
+  type        = "list"
+  description = "A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an ALARM state from any other state.  If set, this list takes precedence over notify_arns."
+  default     = []
+}
+
+variable "ok_actions" {
+  type        = "list"
+  description = "A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an OK state from any other state. If set, this list takes precedence over notify_arns."
+  default     = []
+}
+
+variable "insufficient_data_actions" {
+  type        = "list"
+  description = "A list of ARNs (i.e. SNS Topic ARN) to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state. If set, this list takes precedence over notify_arns."
+  default     = []
 }
 
 variable "alb_name" {
@@ -108,4 +127,10 @@ variable "target_response_time_alarm_description" {
   type        = "string"
   description = "The string to format and use as the target response time alarm description."
   default     = "Target Response Time average for %v over %v last %d minute(s) over %v period(s)"
+}
+
+variable "treat_missing_data" {
+  type        = "string"
+  description = "Sets how alarms handle missing data points. Values supported: missing, ignore, breaching and notBreaching."
+  default     = "missing"
 }


### PR DESCRIPTION
# What
Ability to influence alarm attributes regarding missing data, and expose more granularity to available alarm transition action lists.

# How
Add new input variables
-`treat_missing_data` 

These new values override existing `notify_arns`:
-`ok_actions`
-`alarm_actions` 
-`insufficient_data_actions` 

