### PR TITLE
Add ELB 5XX alarm and threshold variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ module "alb_alarms" {
 | target_3xx_count_threshold | The maximum count of 3XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_4xx_count_threshold | The maximum count of 4XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_5xx_count_threshold | The maximum count of 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| elb_5xx_count_threshold | The maximum count of ELB 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_group_arn_suffix | The ARN suffix of ALB Target Group. | string | - | yes |
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,6 +22,7 @@
 | target_3xx_count_threshold | The maximum count of 3XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_4xx_count_threshold | The maximum count of 4XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_5xx_count_threshold | The maximum count of 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
+| elb_5xx_count_threshold | The maximum count of ELB 5XX requests over a period. A negative value will disable the alert. | string | `25` | no |
 | target_group_arn_suffix | The ARN suffix of ALB Target Group. | string | - | yes |
 | target_group_name | The name of the ALB Target Group to monitor. | string | - | yes |
 | target_response_time_alarm_description | The string to format and use as the target response time alarm description. | string | `Target Response Time average for %v over %v last %d minute(s) over %v period(s)` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,12 @@ variable "target_5xx_count_threshold" {
   default     = "25"
 }
 
+variable "elb_5xx_count_threshold" {
+  type        = "string"
+  description = "The maximum count of ELB 5XX requests over a period. A negative value will disable the alert."
+  default     = "25"
+}
+
 variable "httpcode_alarm_description" {
   type        = "string"
   description = "The string to format and use as the httpcode alarm description."


### PR DESCRIPTION
This adds ELB 5XX as an alarm-able metric. This is useful to alarm on when backends are not available to the ALB.

Despite the metric being called "HTTPCode_**ELB**_5XX_Count", this is the correct ALB metric name.
* https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html#load-balancer-metrics-alb