### PR TITLE
allow non-formatted alarm description

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms&utm_content=website
@@ -408,3 +408,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms
   [share_email]: mailto:?subject=terraform-aws-alb-target-group-cloudwatch-sns-alarms&body=https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms?pixel&cs=github&cm=readme&an=terraform-aws-alb-target-group-cloudwatch-sns-alarms
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_3xx_count" {
   statistic                 = "Sum"
   threshold                 = local.thresholds["target_3xx_count"]
   treat_missing_data        = var.treat_missing_data
-  alarm_description         = format(var.httpcode_alarm_description, "3XX", module.this.id, local.thresholds["target_3xx_count"], var.period / 60, var.evaluation_periods)
+  alarm_description         = try(format(var.httpcode_alarm_description, "3XX", module.this.id, local.thresholds["target_3xx_count"], var.period / 60, var.evaluation_periods), var.httpcode_alarm_description)
   alarm_actions             = local.alarm_actions
   ok_actions                = local.ok_actions
   insufficient_data_actions = local.insufficient_data_actions
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_4xx_count" {
   statistic                 = "Sum"
   threshold                 = local.thresholds["target_4xx_count"]
   treat_missing_data        = var.treat_missing_data
-  alarm_description         = format(var.httpcode_alarm_description, "4XX", module.this.id, local.thresholds["target_4xx_count"], var.period / 60, var.evaluation_periods)
+  alarm_description         = try(format(var.httpcode_alarm_description, "4XX", module.this.id, local.thresholds["target_4xx_count"], var.period / 60, var.evaluation_periods), var.httpcode_alarm_description)
   alarm_actions             = local.alarm_actions
   ok_actions                = local.ok_actions
   insufficient_data_actions = local.insufficient_data_actions
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   statistic                 = "Sum"
   threshold                 = local.thresholds["target_5xx_count"]
   treat_missing_data        = var.treat_missing_data
-  alarm_description         = format(var.httpcode_alarm_description, "5XX", module.this.id, local.thresholds["target_5xx_count"], var.period / 60, var.evaluation_periods)
+  alarm_description         = try(format(var.httpcode_alarm_description, "5XX", module.this.id, local.thresholds["target_5xx_count"], var.period / 60, var.evaluation_periods), var.httpcode_alarm_description)
   alarm_actions             = local.alarm_actions
   ok_actions                = local.ok_actions
   insufficient_data_actions = local.insufficient_data_actions
@@ -136,7 +136,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_elb_5xx_count" {
   statistic                 = "Sum"
   threshold                 = local.thresholds["elb_5xx_count"]
   treat_missing_data        = var.treat_missing_data
-  alarm_description         = format(var.httpcode_alarm_description, "ELB-5XX", module.this.id, local.thresholds["elb_5xx_count"], var.period / 60, var.evaluation_periods)
+  alarm_description         = try(format(var.httpcode_alarm_description, "ELB-5XX", module.this.id, local.thresholds["elb_5xx_count"], var.period / 60, var.evaluation_periods), var.httpcode_alarm_description)
   alarm_actions             = local.alarm_actions
   ok_actions                = local.ok_actions
   insufficient_data_actions = local.insufficient_data_actions
@@ -155,7 +155,7 @@ resource "aws_cloudwatch_metric_alarm" "target_response_time_average" {
   statistic                 = "Average"
   threshold                 = local.thresholds["target_response_time"]
   treat_missing_data        = var.treat_missing_data
-  alarm_description         = format(var.target_response_time_alarm_description, module.this.id, local.thresholds["target_response_time"], var.period / 60, var.evaluation_periods)
+  alarm_description         = try(format(var.target_response_time_alarm_description, module.this.id, local.thresholds["target_response_time"], var.period / 60, var.evaluation_periods), var.target_response_time_alarm_description)
   alarm_actions             = local.alarm_actions
   ok_actions                = local.ok_actions
   insufficient_data_actions = local.insufficient_data_actions


### PR DESCRIPTION
Signed-off-by: Jordan Richlen <jmrichlen@gmail.com>

## what
* allow `httpcode_alarm_description` and `target_response_time_alarm_description` to be non-formatted string instead of requiring formatting

## why
* Alarms are used to trigger notifications in our on-call system. The on-call system uses alarm_description to determine which team to call. That string needs to be a team name and cannot contain additional formatted text.

## references
I've created a simplified example of the problem.

Below is an example of the error triggered by passing a non-formattable string.
![image](https://user-images.githubusercontent.com/9574264/192658536-ee7c7b40-5d78-4d81-b9a3-febf2cbfe8d5.png)

And here's an example with the solution.
![image](https://user-images.githubusercontent.com/9574264/192658771-79fb3dc8-31ce-498a-ae36-45a21d91dc08.png)


Related PR - https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms/pull/32

closes: https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms/issues/50